### PR TITLE
Fix numberOfTaps in the example

### DIFF
--- a/flutter_embed_unity/example/lib/main.dart
+++ b/flutter_embed_unity/example/lib/main.dart
@@ -61,7 +61,7 @@ class _ExampleAppState extends State<ExampleApp> {
                         // A message has been received from a Unity script
                         if(data == "touch"){
                           setState(() {
-                            _numberOfTaps = _numberOfTaps++;
+                            _numberOfTaps += 1;
                           });
                         }
                         else if(data == "scene_loaded") {

--- a/flutter_embed_unity_2022_3_android/example/lib/main.dart
+++ b/flutter_embed_unity_2022_3_android/example/lib/main.dart
@@ -61,7 +61,7 @@ class _ExampleAppState extends State<ExampleApp> {
                         // A message has been received from a Unity script
                         if(data == "touch"){
                           setState(() {
-                            _numberOfTaps = _numberOfTaps++;
+                            _numberOfTaps += 1;
                           });
                         }
                         else if(data == "scene_loaded") {

--- a/flutter_embed_unity_2022_3_ios/example/lib/main.dart
+++ b/flutter_embed_unity_2022_3_ios/example/lib/main.dart
@@ -61,7 +61,7 @@ class _ExampleAppState extends State<ExampleApp> {
                         // A message has been received from a Unity script
                         if(data == "touch"){
                           setState(() {
-                            _numberOfTaps = _numberOfTaps++;
+                            _numberOfTaps += 1;
                           });
                         }
                         else if(data == "scene_loaded") {


### PR DESCRIPTION
The example contains a tap counter, that never increments as intended.

This is caused by using ++ in `_numberOfTaps++`.

From the [docs](https://dart.dev/language/operators)
++var | var  =  var + 1 (expression value is var + 1)
-- | --
var++ | var  =  var + 1 (expression value is var)


I've simply changed it to `+= 1` for clarity.

```diff
- _numberOfTaps = _numberOfTaps++;
+ _numberOfTaps += 1;
```