### PR TITLE
Fix new input system touches on android.

### DIFF
--- a/flutter_embed_unity_2022_3_android/android/src/main/kotlin/com/learntoflutter/flutter_embed_unity_android/unity/CopyMotionEvent.kt
+++ b/flutter_embed_unity_2022_3_android/android/src/main/kotlin/com/learntoflutter/flutter_embed_unity_android/unity/CopyMotionEvent.kt
@@ -1,0 +1,56 @@
+// source https://gist.github.com/sebschaef/b803da53217c88e8c691aeed08602193
+
+package com.learntoflutter.flutter_embed_unity_android.unity
+
+import android.view.MotionEvent
+
+/*
+  Copies a MotionEvent. Use the named parameters to modify immutable properties.
+  Don't forget to recycle the original event if it is not used anymore.
+*/
+fun MotionEvent.copy(
+    downTime: Long = getDownTime(),
+    eventTime: Long = getEventTime(),
+    action: Int = getAction(),
+    pointerCount: Int = getPointerCount(),
+    pointerProperties: Array<MotionEvent.PointerProperties>? =
+        (0 until getPointerCount())
+            .map { index ->
+                MotionEvent.PointerProperties().also { pointerProperties ->
+                    getPointerProperties(index, pointerProperties)
+                }
+            }
+            .toTypedArray(),
+    pointerCoords: Array<MotionEvent.PointerCoords>? =
+        (0 until getPointerCount())
+            .map { index ->
+                MotionEvent.PointerCoords().also { pointerCoords ->
+                    getPointerCoords(index, pointerCoords)
+                }
+            }
+            .toTypedArray(),
+    metaState: Int = getMetaState(),
+    buttonState: Int = getButtonState(),
+    xPrecision: Float = getXPrecision(),
+    yPrecision: Float = getYPrecision(),
+    deviceId: Int = getDeviceId(),
+    edgeFlags: Int = getEdgeFlags(),
+    source: Int = getSource(),
+    flags: Int = getFlags()
+): MotionEvent =
+    MotionEvent.obtain(
+        downTime,
+        eventTime,
+        action,
+        pointerCount,
+        pointerProperties,
+        pointerCoords,
+        metaState,
+        buttonState,
+        xPrecision,
+        yPrecision,
+        deviceId,
+        edgeFlags,
+        source,
+        flags
+    )

--- a/flutter_embed_unity_2022_3_android/android/src/main/kotlin/com/learntoflutter/flutter_embed_unity_android/unity/UnityPlayerSingleton.kt
+++ b/flutter_embed_unity_2022_3_android/android/src/main/kotlin/com/learntoflutter/flutter_embed_unity_android/unity/UnityPlayerSingleton.kt
@@ -81,7 +81,19 @@ class UnityPlayerSingleton private constructor (activity: Activity) : UnityPlaye
     override fun onTouchEvent(motionEvent: MotionEvent): Boolean {
         motionEvent.source = InputDevice.SOURCE_TOUCHSCREEN
 //        Log.i(logTag, "onTouchEvent")
-        return super.onTouchEvent(motionEvent)
+    
+         // true for Flutter Virtual Display, false for Hybrid composition.
+        if (motionEvent.deviceId == 0) {        
+            /* 
+              Flutter creates a touchscreen motion event with deviceId 0. (https://github.com/flutter/flutter/blob/34b454f42dd6f8721dfe43fc7de5d215705b5e52/packages/flutter/lib/src/services/platform_views.dart#L639)
+              Unity's new Input System package does not detect these touches, copy the motion event to change the immutable deviceId.
+            */
+            val modifiedEvent = motionEvent.copy(deviceId = -1)
+            motionEvent.recycle()
+            return super.onTouchEvent(modifiedEvent)
+        } else {
+            return super.onTouchEvent(motionEvent)
+        }
     }
 
     override fun onWindowVisibilityChanged(visibility: Int) {


### PR DESCRIPTION
## Description
Unity code or UI that uses touch events using the (new) Input System package doesn't work when using this widget.  
This PR adds a workaround to make touch input work using the new Input System.

### Context
I've been experimenting and this does work in a platform view using Hybrid composition, it is just Virtual display that is broken.  
After logging both implementations I noticed that touch events using HC have a positive integer `deviceId`, which can be anything for different devices like 2, 3, 4, or 14.  
VD touch events will always have a deviceId of 0.

### Fix
Change the deviceId if it is 0.  
I chose `-1` as that works in Unity and seems unlikely to conflict with any actual hardware.  

The only downside is that we need to copy the full MotionEvent because the deviceId is immutable.  
However I believe performance impact is negilible.

Changing the deviceId does not make any difference to the old input system, which likely ignores it anyway.  

### Testing
- Use the example project.
- Add a canvas with a button. Make sure the eventsystem uses the new input system.  
![canvas](https://github.com/learntoflutter/flutter_embed_unity/assets/11444698/4106709f-02b0-4ed4-b6f9-1385b4862427)
![eventsystem](https://github.com/learntoflutter/flutter_embed_unity/assets/11444698/690e79ca-3c07-4794-9f3a-bf0b517dcb09)
- Now try pressing the canvas button while running the Flutter app.  
- It doesn't work without this fix.  

So far I've tested this with Unity 2022.3.21 on:  
- Samsung S20FE, Android 13
- Samsung S8, Android 9,
- Wilefox Swift, Android 7,
- Samsung J5 Android 6,

### Video
I should probably have used a bigger button, but you can see the fix in these screen recordings.  
<table>
<tr>
<td>

https://github.com/learntoflutter/flutter_embed_unity/assets/11444698/d4e57c81-7ace-4738-a5fb-29223fc53652



</td>

<td>

https://github.com/learntoflutter/flutter_embed_unity/assets/11444698/466b12d4-079d-4a37-8448-27fc1a938807



</td>
</tr>
</table>



##
Just to be sure this PR might need some additional testing on different Android devices and Unity versions.  
However I'm confident  that `deviceId = -1` will be safe for nearly anyone.