### PR TITLE
Modify the Xcode project linker flags and Data folder on ios export.

### DIFF
--- a/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterIos.cs
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterIos.cs
@@ -40,6 +40,26 @@ internal class ProjectExporterIos : ProjectExporter
         PBXProject pbxProject = new PBXProject();
         pbxProject.ReadFromFile(pbxProjFileInfo.FullName);
         pbxProject.SetBuildProperty(pbxProject.ProjectGuid(), "ENABLE_BITCODE", "NO");
+
+        // Add linker flags to Unity-iPhone
+        pbxProject.AddBuildProperty(pbxProject.ProjectGuid(), "OTHER_LDFLAGS", "-Wl,-U,_FlutterEmbedUnityIos_sendToFlutter");
+
+        // Change the Data folder Target Membership
+        string dataGuid = pbxProject.FindFileGuidByProjectPath("Data");
+        if(!string.IsNullOrEmpty(dataGuid)) {
+            // Add the Data folder to the UnityFramework target
+            string frameworkGuid = pbxProject.GetUnityFrameworkTargetGuid();
+            pbxProject.AddFileToBuild(frameworkGuid, dataGuid);
+
+            // Remove the Data folder from the Unity-iPhone target
+            string mainGuid = pbxProject.GetUnityMainTargetGuid();
+            pbxProject.RemoveFileFromBuild(mainGuid, dataGuid);
+        }
+        else {
+            Debug.LogError("Could not find the 'Data' folder in the `Unity-iPhone project.");
+        }
+
+        // Save changes
         pbxProject.WriteToFile(pbxProjFileInfo.FullName);
 
         // Delete the BurstDebugInformation folder


### PR DESCRIPTION
### Related issue
Fixes #1 

### Description
This automates the 2 manual steps that need to be done after each ios export.

- Add the linker flags `-Wl,-U,_FlutterEmbedUnityIos_sendToFlutter`
- Set the Data folder target membership to `UnityFramework`

I tested a fresh export using Unity 2022.3.21f1 and was able to run the example project on an iPad using Xcode 15.
Besides generic Xcode stuff like setting the signing id, the only manual step was to to add Unity-iPhone to Runner.

I wasn't able to append an existing ios export, as the export dialog always cleared the destination folder.
Therefore I haven't tested if this runs into any issues  on an already edited Xcode project.