### PR TITLE
Fix exporter compilation error when Unity is not 2022.3.

### DIFF
--- a/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExportChecker.cs
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExportChecker.cs
@@ -97,8 +97,8 @@ internal class ProjectExportChecker
     private bool PreCheckCommon(ref List<string> precheckWarnings, NamedBuildTarget namedBuildTarget, BuildTargetGroup buildTargetGroup)
     {
 #if !UNITY_2022_3
-        ShowErrorMessage("This plugin only supports Unity 2022.3 LTS (Long Term Support).");
-        return ProjectExportCheckerResult.Failure();
+        ProjectExportHelpers.ShowErrorMessage("This plugin only supports Unity 2022.3 LTS (Long Term Support).");
+        return false;
 #endif
 
         if (PlayerSettings.GetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup) != ScriptingImplementation.IL2CPP)


### PR DESCRIPTION
### Description
A fix for a very minor issue.  
The exporter script is supposed to show an error dialog on Unity versions that aren't 2022.3.

However the code within `#if !UNITY_2022_3` doesn't even compile, it likely got left behind in a refactor because the 2022.3 compiler doesn't validate it.

This PR simply makes it compile again.

```diff
#if !UNITY_2022_3
-        ShowErrorMessage("This plugin only supports Unity 2022.3 LTS (Long Term Support).");
-        return ProjectExportCheckerResult.Failure();
+        ProjectExportHelpers.ShowErrorMessage("This plugin only supports Unity 2022.3 LTS (Long Term Support).");
+        return false;
#endif
```

