### PR TITLE
Fix duplicate and missing namespace in UnityLibrary build.gradle.

### DIFF
--- a/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterAndroid.cs
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterAndroid.cs
@@ -99,10 +99,28 @@ internal class ProjectExporterAndroid : ProjectExporter
             return;
         }
         string buildGradleContents = File.ReadAllText(buildGradleFile.FullName);
-        Regex regexAndroidBlock = new Regex(Regex.Escape("android {"));
-        buildGradleContents = regexAndroidBlock.Replace(buildGradleContents, "android {\n\tnamespace 'com.unity3d.player'", 1);
-        File.WriteAllText(buildGradleFile.FullName, buildGradleContents);
-        Debug.Log($"Added namespace 'com.unity3d.player' to {buildGradleFile.FullName} for Gradle 8 compatibility");
+        // some unity versions might already include it
+        if(!buildGradleContents.Contains("namespace")) {
+            Regex regexAndroidBlock = new Regex(Regex.Escape("android {"));
+            buildGradleContents = regexAndroidBlock.Replace(buildGradleContents, "android {\n\tnamespace 'com.unity3d.player'", 1);
+            File.WriteAllText(buildGradleFile.FullName, buildGradleContents);
+            Debug.Log($"Added namespace 'com.unity3d.player' to {buildGradleFile.FullName} for Gradle 8 compatibility");
+        }
+		
+        // (optional) Add the namespace 'com.UnityTechnologies.XR.Manifest' to unityLibrary\xrmanifest.androidlib\build.gradle
+        // for compatibility with Gradle 8
+        FileInfo xrBuildGradleFile = new FileInfo(Path.Combine(exportPath, "xrmanifest.androidlib", "build.gradle"));
+        if(xrBuildGradleFile.Exists) {
+            string xrBuildGradleContents = File.ReadAllText(xrBuildGradleFile.FullName);
+            // some unity versions might already include it
+            if(!xrBuildGradleContents.Contains("namespace")) {
+                Regex regexAndroidBlock = new Regex(Regex.Escape("android {"));
+                xrBuildGradleContents = regexAndroidBlock.Replace(xrBuildGradleContents, "android {\n\tnamespace 'com.UnityTechnologies.XR.Manifest'", 1);
+                File.WriteAllText(xrBuildGradleFile.FullName, xrBuildGradleContents);
+                Debug.Log($"Added namespace 'com.UnityTechnologies.XR.Manifest' to {xrBuildGradleFile.FullName} for Gradle 8 compatibility");
+            }
+        }
+        
 
         DirectoryInfo burstDebugInformation = new DirectoryInfo(Path.Join(exportPath, "..", "unityLibrary_BurstDebugInformation_DoNotShip"));
         if(burstDebugInformation.Exists) {


### PR DESCRIPTION
This PR fixes 2 issues regarding the `namespace` definitions in UnityLibrary.

## 1 - duplicate namespace

The android exporter contains a section to add a `namespace` to the `build.grade` file in Unitylibrary.
https://github.com/learntoflutter/flutter_embed_unity/blob/2af5a0b6b14559abd993784a6bc26463b63b1377/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterAndroid.cs#L94-L105


Exporting with Unity 2022.3.58 results in a duplicate namespace. But Unity 2022.3.21 does NOT.
```groovy
android {
    namespace 'com.unity3d.player'
    namespace "com.unity3d.player"
```
Somewhere between 2022.3.31 and 2022.3.58 Unity updated to add their namespace, and this export doesn't check if it already exists.

## 2 - missing xrmanifest namespace
When you use Gradle 8 and a Unity version that does not trigger **(1)** , you get a namespace error for xrmanifest:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':unityLibrary:xrmanifest.androidlib'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: C:\Users\HNK\Downloads\flutter_embed_unity-main\flutter_embed_unity\example\android\unityLibrary\xrmanifest.androidlib\build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.


```

## Solution
- Add a check if the file already contains 'namespace'.
- Use the same replace logic for `unityLibrary/build.gradle` and `unityLibrary/xrmanifest.androidlib/build.gradle`.

