### PR TITLE
[Flutter 3.29] Update documentation for Kotlin gradle syntax

### DIFF
--- a/flutter_embed_unity/README.md
+++ b/flutter_embed_unity/README.md
@@ -309,6 +309,13 @@ dependencies {
     implementation project(':unityLibrary')
 }
 ```
+```kotlin
+// alternative for build.gradle.kts
+dependencies {
+    implementation(project(":unityLibrary"))
+}
+```
+
 
 ![5](https://github.com/jamesncl/flutter_embed_unity/assets/15979056/04e44ff4-755c-457b-9267-d9c4735559fc)
 
@@ -317,6 +324,10 @@ dependencies {
 - Add the exported unity project to the gradle build by including it in `<your flutter project>/android/settings.gradle`:
 ```
 include ':unityLibrary'
+```
+```kotlin
+// alternative for settings.gradle.kts
+include(":unityLibrary")
 ```
 
 ![6](https://github.com/jamesncl/flutter_embed_unity/assets/15979056/11721c31-2d76-4451-81bf-c0a9fa4bd62e)
@@ -332,6 +343,19 @@ allprojects {
         // Add this:
         flatDir {
             dirs "${project(':unityLibrary').projectDir}/libs"
+        }
+    }
+}
+```
+```kotlin
+// alternative for build.gradle.kts
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        // Add this:
+        flatDir {
+            dirs(file("${project(":unityLibrary").projectDir}/libs"))
         }
     }
 }
@@ -354,7 +378,9 @@ unityStreamingAssets=
 
 If you are using XR features in Unity (eg ARFoundation) you need to perform some additional configuration on your project. First, make sure you check Unity's project validation checks: in your Unity project, go to `Project Settings -> XR Plug-in Management -> Project Validation`, and fix any problems.
 
-- Add `include ':unityLibrary:xrmanifest.androidlib'` to your `android/settings.gradle`:
+- Add `include ':unityLibrary:xrmanifest.androidlib'` to your `android/settings.gradle` or  
+`include(":unityLibrary:xrmanifest.androidlib")` for `android/settings.gradle.kts`:
+
 
 ![6b](https://github.com/jamesncl/flutter_embed_unity/assets/15979056/3a51afd3-0d3c-4fe9-8bc1-be67daff6e74)
 


### PR DESCRIPTION
Since Flutter 3.29, new projects will use the Kotin gradle DSL.  
Files like `build.gradle` and `settings.gradle` now have a `.gradle.kts` extension.


Besides the file extension change, the syntax is different.

For example:
```diff
- implementation project(':unityLibrary')
+ implementation(project(":unityLibrary"))
````

```diff
flatDir {
-    dirs "${project(':unityLibrary').projectDir}/libs"
+    dirs(file("${project(":unityLibrary").projectDir}/libs"))
}
```

This PR adds this new syntax as alternative code blocks in the README.

##

To reproduce and test this:
- delete `android` folder of the example.
- Regenerate it with Flutter 3.29 by running 
```
flutter create --org=com.learntoflutter. --project-name=flutter_embed_unity_example
```
- Follow the new readme for .gradle.kts files
- export unity
- build the flutter example
- Follow any flutter build error instructions. In my case:
  - set minsdk to 22 in app/build.gradle
  - remove `ndkPath` from unitylibary/build.gradle
  - set ndkVersion to "27.0.12077973" in app/build.gradle
- example now runs with Flutter 3.29 gradle setup.