### PR TITLE
Add support for command line (batchmode) to Unity exports.

### DIFF
--- a/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExportHelpers.cs
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExportHelpers.cs
@@ -1,14 +1,20 @@
 using System.IO;
 using UnityEditor;
+using UnityEngine;
 
 internal class ProjectExportHelpers
 {
     static internal void ShowErrorMessage(string errorMessage)
     {
-        EditorUtility.DisplayDialog(
-                        "Export incomplete",
-                        errorMessage,
-                        "Okay");
+        if (!Application.isBatchMode) {
+            EditorUtility.DisplayDialog(
+                            "Export incomplete",
+                            errorMessage,
+                            "Okay");
+        } else {
+            // We don't have any UI to help the user, abort the export.
+            throw new System.Exception(errorMessage);
+        }
     }
 
     static internal void MoveContentsOfDirectory(DirectoryInfo from, DirectoryInfo to)

--- a/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporter.cs
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporter.cs
@@ -11,6 +11,13 @@ internal abstract class ProjectExporter {
 
         if (report.summary.result != BuildResult.Succeeded) {
             Debug.LogError("Building project for Flutter failed");
+            
+            if (Application.isBatchMode) {
+
+                // throwing an exception shows an error on the command line, exit(1) doesn't.
+                throw new System.Exception("Building project for Flutter failed");
+                // EditorApplication.Exit(1);
+            }
         }
         else {
             TransformExportedProject(buildPlayerOptions.locationPathName);
@@ -20,6 +27,10 @@ internal abstract class ProjectExporter {
                 Debug.LogWarning(log);
             }
             Debug.Log($"Building project for Flutter succeeded");
+
+            if (Application.isBatchMode) {
+                EditorApplication.Exit(0);
+            }
         }
     }
 

--- a/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs
@@ -1,0 +1,117 @@
+using UnityEditor;
+using UnityEngine;
+
+public class ProjectExporterBatchmode
+{
+    private static ProjectExportChecker projectExportChecker = new ProjectExportChecker();
+
+    // Functions to export from the command line using Unity batchmode.
+    //
+    // It is advised to run an export from the Unity Editor first, to make sure your project settings are correct.
+    // Checks that open dialogs in the Unity Editor will simply fail on the command line.
+    //
+    // Make sure to use -quit in your command, to ensure the headless Unity engine always terminates in the end.
+    //
+    // Unity documentation https://docs.unity3d.com/2022.3/Documentation/Manual/EditorCommandLineArguments.html
+
+
+
+
+
+    // Export command for Android & iOS. The specific platform is based on `-buildTarget`.
+    // -buildTarget Android
+    // -buildTarget iOS
+    //
+    // <unity path> -projectPath <unity project path> -batchmode -buildTarget Android -executeMethod ProjectExporterBatchmode.ExportProject -exportPath <output path> -quit
+
+    public static void ExportProject()
+    {
+        BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
+
+        if (target == BuildTarget.Android)
+        {
+            ExportProjectAndroid();
+        } 
+        else if ( target == BuildTarget.iOS)
+        {
+            ExportProjectIos();
+        }
+        else
+        {
+            throw new System.Exception("Invalid buildtarget during batchmode export.");
+        }
+    }
+
+
+    public static void ExportProjectAndroid()
+    {
+        if (!Application.isBatchMode)
+        {
+            return;
+        }
+
+        Debug.Log("Exporting Android project in batchmode.");
+      
+        ProjectExportCheckerResult result = projectExportChecker.PreCheckAndroid();
+
+#if UNITY_ANDROID
+        if (result.IsSuccessful)
+        {
+            new ProjectExporterAndroid().Export(result.BuildPlayerOptions, result.PrecheckWarnings);
+        } else
+        {
+            throw new System.Exception("Android PreBuid checks failed.");
+        }
+#else
+        throw new System.Exception("Build platform is not Android.");
+#endif
+
+    }
+
+    // public so this function can be called directly from the command line.
+    public static void ExportProjectIos()
+    {
+
+        if (!Application.isBatchMode)
+        {
+            return;
+        }
+
+        Debug.Log("Exporting iOS project in batchmode.");
+
+        
+        // Using UNITY_IOS preprocessor because 'using UnityEditor.iOS.Xcode' is only available with iOS build tools
+        ProjectExportCheckerResult result = projectExportChecker.PreCheckIos();
+#if UNITY_IOS
+        if(result.IsSuccessful) {
+            new ProjectExporterIos().Export(result.BuildPlayerOptions, result.PrecheckWarnings);
+        } else
+        {
+            throw new System.Exception("iOS PreBuid checks failed.");
+        }
+#else
+        throw new System.Exception("Build platform is not iOS.");
+#endif
+        
+    }
+
+
+    // Get the build destination (unityLibrary directory) from the comand line argument -exportPath
+    public static string GetExportPath()
+    {
+        return GetArg("-exportPath");
+    }
+
+    private static string GetArg(string name)
+    {
+        var args = System.Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == name && args.Length > i + 1)
+            {
+                return args[i + 1];
+            }
+        }
+        return null;
+    }
+}

--- a/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs.meta
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00543fbcd09e1fe4daf0ae44915d42db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExportChecker.cs
+++ b/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExportChecker.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.Build;
+using UnityEngine;
 
 internal class ProjectExportCheckerResult
 {
@@ -144,6 +146,12 @@ internal class ProjectExportChecker
 
     private ProjectExportCheckerResult PrepareExportDirectory(String subfolderName, String folderName, List<string> precheckWarnings)
     {
+        if (Application.isBatchMode)
+        {
+            // from the command line, run a version that doesn't use Dialogs.
+            return PrepareExportDirectoryBatchmode(subfolderName, folderName, precheckWarnings);
+        }
+
         bool confirmOpenFolderSelection = EditorUtility.DisplayDialog(
                     "Select export directory",
                     "In the next window, select the export directory. This should be " +
@@ -209,4 +217,78 @@ internal class ProjectExportChecker
             }
         }
     }
+
+    private ProjectExportCheckerResult PrepareExportDirectoryBatchmode(String subfolderName, String folderName, List<string> precheckWarnings)
+    {
+        if(!Application.isBatchMode)
+        {
+            return PrepareExportDirectory(subfolderName, folderName, precheckWarnings);
+        }
+
+        string path = ProjectExporterBatchmode.GetExportPath();
+        if(path == null)
+        {
+            ProjectExportHelpers.ShowErrorMessage("No -exportPath command line argument found");
+            return ProjectExportCheckerResult.Failure();
+        }
+
+        DirectoryInfo selectedDirectory = new DirectoryInfo(path);
+
+        // We can't get the current BuildPlayerOptions from the active Unity Editor.
+        // Create a new instance and set all relevant settings.
+
+        // Include some build options.
+        BuildOptions buildOptions = BuildOptions.None;
+        if (EditorUserBuildSettings.development)
+        {
+            buildOptions |= BuildOptions.Development;
+        }
+
+        if (EditorUserBuildSettings.connectProfiler)
+        {
+            buildOptions |= BuildOptions.ConnectWithProfiler;
+        }
+        if (EditorUserBuildSettings.allowDebugging)
+        {
+            buildOptions |= BuildOptions.AllowDebugging;
+        }
+
+        BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions
+        {
+            scenes = EditorBuildSettings.scenes
+                        .Where(s => s.enabled)
+                        .Select(s => s.path)
+                        .ToArray(),
+            target = EditorUserBuildSettings.activeBuildTarget,
+            locationPathName = selectedDirectory.FullName,
+            options = buildOptions
+        };
+
+        // The same directory checks as in PrepareExportDirectory, but don't ask permission to create and delete directories
+
+        if (selectedDirectory.Name.Equals(subfolderName)) 
+        {
+            buildPlayerOptions.locationPathName = Path.Combine(buildPlayerOptions.locationPathName, folderName);
+            selectedDirectory = new DirectoryInfo(buildPlayerOptions.locationPathName);
+            Directory.CreateDirectory(buildPlayerOptions.locationPathName);
+        }
+
+        if (!selectedDirectory.Name.Equals(folderName) || selectedDirectory.Parent == null || selectedDirectory.Parent.Name != subfolderName)
+        {
+            ProjectExportHelpers.ShowErrorMessage($"Expected a folder named {folderName} inside '{subfolderName}' folder. " +
+                $"Check the plugin documentation: you need to select '<your flutter project>/{subfolderName}/{folderName}'. " +
+                "Aborting export");
+            return ProjectExportCheckerResult.Failure();
+        }
+        else
+        {
+            if (Directory.Exists(buildPlayerOptions.locationPathName) && Directory.GetFileSystemEntries(buildPlayerOptions.locationPathName).Length != 0)
+            {
+                Debug.Log($"Deleting existing contents of {selectedDirectory.FullName}");
+                Directory.Delete(selectedDirectory.FullName, true);
+            }
+            return ProjectExportCheckerResult.Success(buildPlayerOptions, precheckWarnings);
+        }
+    }
+
 }

--- a/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExportHelpers.cs
+++ b/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExportHelpers.cs
@@ -1,14 +1,20 @@
 using System.IO;
 using UnityEditor;
+using UnityEngine;
 
 internal class ProjectExportHelpers
 {
     static internal void ShowErrorMessage(string errorMessage)
     {
-        EditorUtility.DisplayDialog(
-                        "Export incomplete",
-                        errorMessage,
-                        "Okay");
+        if (!Application.isBatchMode) {
+            EditorUtility.DisplayDialog(
+                            "Export incomplete",
+                            errorMessage,
+                            "Okay");
+        } else {
+            // We don't have any UI to help the user, abort the export.
+            throw new System.Exception(errorMessage);
+        }
     }
 
     static internal void MoveContentsOfDirectory(DirectoryInfo from, DirectoryInfo to)

--- a/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExporter.cs
+++ b/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExporter.cs
@@ -11,6 +11,13 @@ internal abstract class ProjectExporter {
 
         if (report.summary.result != BuildResult.Succeeded) {
             Debug.LogError("Building project for Flutter failed");
+            
+            if (Application.isBatchMode) {
+
+                // throwing an exception shows an error on the command line, exit(1) doesn't.
+                throw new System.Exception("Building project for Flutter failed");
+                // EditorApplication.Exit(1);
+            }
         }
         else {
             TransformExportedProject(buildPlayerOptions.locationPathName);
@@ -20,6 +27,10 @@ internal abstract class ProjectExporter {
                 Debug.LogWarning(log);
             }
             Debug.Log($"Building project for Flutter succeeded");
+
+            if (Application.isBatchMode) {
+                EditorApplication.Exit(0);
+            }
         }
     }
 

--- a/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs
+++ b/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs
@@ -1,0 +1,117 @@
+using UnityEditor;
+using UnityEngine;
+
+public class ProjectExporterBatchmode
+{
+    private static ProjectExportChecker projectExportChecker = new ProjectExportChecker();
+
+    // Functions to export from the command line using Unity batchmode.
+    //
+    // It is advised to run an export from the Unity Editor first, to make sure your project settings are correct.
+    // Checks that open dialogs in the Unity Editor will simply fail on the command line.
+    //
+    // Make sure to use -quit in your command, to ensure the headless Unity engine always terminates in the end.
+    //
+    // Unity documentation https://docs.unity3d.com/2022.3/Documentation/Manual/EditorCommandLineArguments.html
+
+
+
+
+
+    // Export command for Android & iOS. The specific platform is based on `-buildTarget`.
+    // -buildTarget Android
+    // -buildTarget iOS
+    //
+    // <unity path> -projectPath <unity project path> -batchmode -buildTarget Android -executeMethod ProjectExporterBatchmode.ExportProject -exportPath <output path> -quit
+
+    public static void ExportProject()
+    {
+        BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
+
+        if (target == BuildTarget.Android)
+        {
+            ExportProjectAndroid();
+        } 
+        else if ( target == BuildTarget.iOS)
+        {
+            ExportProjectIos();
+        }
+        else
+        {
+            throw new System.Exception("Invalid buildtarget during batchmode export.");
+        }
+    }
+
+
+    public static void ExportProjectAndroid()
+    {
+        if (!Application.isBatchMode)
+        {
+            return;
+        }
+
+        Debug.Log("Exporting Android project in batchmode.");
+      
+        ProjectExportCheckerResult result = projectExportChecker.PreCheckAndroid();
+
+#if UNITY_ANDROID
+        if (result.IsSuccessful)
+        {
+            new ProjectExporterAndroid().Export(result.BuildPlayerOptions, result.PrecheckWarnings);
+        } else
+        {
+            throw new System.Exception("Android PreBuid checks failed.");
+        }
+#else
+        throw new System.Exception("Build platform is not Android.");
+#endif
+
+    }
+
+    // public so this function can be called directly from the command line.
+    public static void ExportProjectIos()
+    {
+
+        if (!Application.isBatchMode)
+        {
+            return;
+        }
+
+        Debug.Log("Exporting iOS project in batchmode.");
+
+        
+        // Using UNITY_IOS preprocessor because 'using UnityEditor.iOS.Xcode' is only available with iOS build tools
+        ProjectExportCheckerResult result = projectExportChecker.PreCheckIos();
+#if UNITY_IOS
+        if(result.IsSuccessful) {
+            new ProjectExporterIos().Export(result.BuildPlayerOptions, result.PrecheckWarnings);
+        } else
+        {
+            throw new System.Exception("iOS PreBuid checks failed.");
+        }
+#else
+        throw new System.Exception("Build platform is not iOS.");
+#endif
+        
+    }
+
+
+    // Get the build destination (unityLibrary directory) from the comand line argument -exportPath
+    public static string GetExportPath()
+    {
+        return GetArg("-exportPath");
+    }
+
+    private static string GetArg(string name)
+    {
+        var args = System.Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == name && args.Length > i + 1)
+            {
+                return args[i + 1];
+            }
+        }
+        return null;
+    }
+}

--- a/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs.meta
+++ b/example_unity_6000_0_project/Assets/FlutterEmbed/Editor/ProjectExporterBatchmode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00543fbcd09e1fe4daf0ae44915d42db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/flutter_embed_unity/README.md
+++ b/flutter_embed_unity/README.md
@@ -285,7 +285,7 @@ public class SendToFlutterTouched : MonoBehaviour
 ## Export your Unity project
 
 To embed Unity into your Flutter app, you need to export your Unity project into a form which we can integrate into the native `android` and / or `ios` part of your Flutter project.
-The `EmbedUnity` assets you have added to your Unity project includes scripts to make this easy, and an Editor menu item to launch them, so you should see an option called `Flutter embed` in the Unity toobar.
+The `EmbedUnity` assets you have added to your Unity project includes scripts to make this easy, and an Editor menu item to launch them, so you should see an option called `Flutter embed` in the Unity toolbar.
 
 - First, create the folder to export your Unity project to. This MUST be either:
   - `<your flutter project>/android/unityLibrary` for Android or
@@ -303,6 +303,9 @@ The `EmbedUnity` assets you have added to your Unity project includes scripts to
 > To learn about the structure of the Unity export you have just made, see [the documentation for Android](https://docs.unity3d.com/Manual/UnityasaLibrary-Android.html) and the [documentation for iOS](https://docs.unity3d.com/Manual/UnityasaLibrary-iOS.html). The export script takes these structures and modifies them for easier integration into Flutter: the Unity console output tells you what changes have been made
 
 The Unity project is now ready to use, but we still haven't actually linked it to our Flutter app.
+
+
+> You can also [Export from the command line](#advanced-export-from-the-command-line) instead.
 
 
 ## Link exported Unity project to your Flutter project
@@ -660,6 +663,87 @@ EmbedUnityPreferences.messageFromUnityListeningBehaviour =
 ```
 
 Currently, having two instances of `EmbedUnity` on the same screen is not supported.
+
+# Advanced: Export from the command line
+> Batchmode support was added after version 1.3.1.  
+If `ProjectExporterBatchmode.ExportProject` doesn't exisit in your Unity project, download and import a newer unitypackage. 
+
+Besides using the Editor menu, you can also export from Unity using the command line.  
+It is advised to try an export using the Editor Menu first, as that will help you check your project settings.
+
+To start you will need the path to 3 directories.
+1. Your Unity install directory:  
+  Mac `/Applications/Unity/Hub/Editor/<version>/Unity.app/Contents/MacOS/Unity`  
+  Windows `C:/Program Files/Unity/Hub/Editor/<version>/Editor/Unity.exe`  
+  Linux `/Applications/Unity/Hub/Editor/<version>/Unity.app/Contents/Linux/Unity`  
+2. Your Unity project directory.
+3. Your output directory.  
+  `<your flutter project>/android/unityLibrary` or `<your flutter project>/ios/unityLibrary`.  
+
+Once you've got all 3, you are ready to export.
+
+Use the `-buildTarget` value `Android` or `iOS` to select your platform.
+
+```bash
+"<unity path>" \
+  -projectPath "<unity project path>" \
+  -batchmode \
+  -nographics \
+  -buildTarget Android \
+  -executeMethod ProjectExporterBatchmode.ExportProject \
+  -exportPath "<output path>" \
+  -quit
+```
+(For windows replace `\` with `^` in CMD or `` ` `` in Powershell)
+
+Or as a single line
+```bash
+"<unity path>" -projectPath "<unity project path>" -batchmode -nographics -buildTarget Android -executeMethod ProjectExporterBatchmode.ExportProject -exportPath "<output path>" -quit
+```
+
+Unity will launch as an invisible (headless) instance in the background. It is important to include `-quit`, otherwise the headless Unity engine might stay active on your machine after the script aborts.
+
+Unity won't display logs and errors in the command line.
+You can find output in the [editor log](https://docs.unity3d.com/2022.3/Documentation/Manual/LogFiles.html) or add the argument `-logFile <path to file>` to log to a specific file.
+
+You might see the following on an exception, but you will need to check the logs for the exact message.
+```
+Aborting batchmode due to failure:
+executeMethod method ProjectExporterBatchmode.ExportProject threw exception.
+```
+
+Check the [Unity documentation](https://docs.unity3d.com/2022.3/Documentation/Manual/EditorCommandLineArguments.html) for more info on building from the command line.
+
+## Windows specific commands
+On windows the command will return instantly, and Unity will finish exporting in the background a little while later.  
+
+You can use start commands, like the examples below, to wait for Unity to complete. 
+
+CMD
+```cmd
+start /wait "" "<unity path>" ^
+ -projectPath "<unity project path>" ^
+ -batchmode ^
+ -nographics ^
+ -buildTarget Android ^
+ -executeMethod ProjectExporterBatchmode.ExportProject ^
+ -exportPath "<output path>" ^
+ -quit
+```
+Powershell
+```powershell
+Start-Process -FilePath "<unity path>" `
+  -ArgumentList `
+    "-projectPath", "<unity project path>", `
+    "-batchmode", `
+    "-nographics", `
+    "-buildTarget", "Android", `
+    "-executeMethod", "ProjectExporterBatchmode.ExportProject", `
+    "-exportPath", "<output path>", `
+    "-quit" `
+  -Wait -PassThru
+```
+
 
 
 # Advanced: AAR compilation for Android


### PR DESCRIPTION
## Description
This PR adds the ability to perform the Unity export from the command line using [batch mode](https://docs.unity3d.com/6000.1/Documentation/Manual/EditorCommandLineArguments.html).

The unity export scripts needed some minor changes to support unity batchmode.
- New public static endpoints to call in a new file  `ProjectExporterBatchmode.cs`.
- Some batch mode checks to avoid using Editor-only features like dialogs.

The current export flow requests users to change settings using dialog windows, instead of doing it automatically.  
In this PR I've kept the same approach and reused most of the existing PreExport checks.  
The only difference is that it will throw an exception where the UI version would show a dialog.

That's why I added a reccomendation in the ReadMe to test an export from the Menu UI first, to validate the project settings.

## Testing
- I exported Android on Widows using Unity 2022.3.58 and 6000.0.49.
  Using both CMD and Powershell.
- I exported iOS on Mac using Unity 2022.3.58 and 6000.0.38
- I exported Android on Mac using Unity 2022.3.58

## More details & instructions (copied from the updated readme)

It is advised to try an export using the Editor Menu first, as that will help you check your project settings.

To start you will need the path to 3 directories.
1. Your Unity install directory:  
  Mac `/Applications/Unity/Hub/Editor/<version>/Unity.app/Contents/MacOS/Unity`  
  Windows `C:/Program Files/Unity/Hub/Editor/<version>/Editor/Unity.exe`  
  Linux `/Applications/Unity/Hub/Editor/<version>/Unity.app/Contents/Linux/Unity`  
2. Your Unity project directory.
3. Your output directory.  
  `<your flutter project>/android/unityLibrary` or `<your flutter project>/ios/unityLibrary`.  

Once you've got all 3, you are ready to export.

Use the `-buildTarget` value `Android` or `iOS` to select your platform.

```bash
"<unity path>" \
  -projectPath "<unity project path>" \
  -batchmode \
  -nographics \
  -buildTarget Android \
  -executeMethod ProjectExporterBatchmode.ExportProject \
  -exportPath "<output path>" \
  -quit
```
(For windows replace `\` with `^` in CMD or `` ` `` in Powershell)

Or as a single line
```bash
"<unity path>" -projectPath "<unity project path>" -batchmode -nographics -buildTarget Android -executeMethod ProjectExporterBatchmode.ExportProject -exportPath "<output path>" -quit
```

Unity will launch as an invisible (headless) instance in the background. It is important to include `-quit`, otherwise the headless Unity engine might stay active on your machine after the script aborts.

Unity won't display logs and errors in the command line.
You can find output in the [editor log](https://docs.unity3d.com/2022.3/Documentation/Manual/LogFiles.html) or add the argument `-logFile <path to file>` to log to a specific file.

You might see the following on an exception, but you will need to check the logs for the exact message.
```
Aborting batchmode due to failure:
executeMethod method ProjectExporterBatchmode.ExportProject threw exception.
```

Check the [Unity documentation](https://docs.unity3d.com/2022.3/Documentation/Manual/EditorCommandLineArguments.html) for more info on building from the command line.

### Windows specific commands
On windows the command will return instantly, and Unity will finish exporting in the background a little while later.  

You can use start commands, like the examples below, to wait for Unity to complete. 

CMD
```cmd
start /wait "" "<unity path>" ^
 -projectPath "<unity project path>" ^
 -batchmode ^
 -nographics ^
 -buildTarget Android ^
 -executeMethod ProjectExporterBatchmode.ExportProject ^
 -exportPath "<output path>" ^
 -quit
```
Powershell
```powershell
Start-Process -FilePath "<unity path>" `
  -ArgumentList `
    "-projectPath", "<unity project path>", `
    "-batchmode", `
    "-nographics", `
    "-buildTarget", "Android", `
    "-executeMethod", "ProjectExporterBatchmode.ExportProject", `
    "-exportPath", "<output path>", `
    "-quit" `
  -Wait -PassThru
```
