### PR TITLE
Improve SendToFlutter platform checks

### DIFF
--- a/example_unity_2022_3_project/Assets/FlutterEmbed/SendToFlutter/SendToFlutter.cs
+++ b/example_unity_2022_3_project/Assets/FlutterEmbed/SendToFlutter/SendToFlutter.cs
@@ -6,21 +6,18 @@ using UnityEngine.SceneManagement;
 public class SendToFlutter
 {
     public static void Send(string data) {
-        if (Application.platform == RuntimePlatform.Android)
+#if UNITY_EDITOR
+        Debug.Log("SendToFlutter - " + data);
+#elif UNITY_ANDROID
+        // Use reflection to call the relevant static Kotlin method in the Android plugin
+        using (AndroidJavaClass sendToFlutterClass = new AndroidJavaClass("com.learntoflutter.flutter_embed_unity_android.messaging.SendToFlutter"))
         {
-            // Use reflection to call the relevant static Kotlin method in the Android plugin
-            using (AndroidJavaClass sendToFlutterClass = new AndroidJavaClass("com.learntoflutter.flutter_embed_unity_android.messaging.SendToFlutter"))
-            {
-                sendToFlutterClass.CallStatic("sendToFlutter", data);
-            }
+            sendToFlutterClass.CallStatic("sendToFlutter", data);
         }
-        else
-        {
-#if UNITY_IOS
-            // Call an obj-C function name
-            FlutterEmbedUnityIos_sendToFlutter(data);
+#elif UNITY_IOS
+        // Call an obj-C function name
+        FlutterEmbedUnityIos_sendToFlutter(data);
 #endif
-        }
     }
 
 #if UNITY_IOS

--- a/example_unity_6000_0_project/Assets/FlutterEmbed/SendToFlutter/SendToFlutter.cs
+++ b/example_unity_6000_0_project/Assets/FlutterEmbed/SendToFlutter/SendToFlutter.cs
@@ -6,21 +6,18 @@ using UnityEngine.SceneManagement;
 public class SendToFlutter
 {
     public static void Send(string data) {
-        if (Application.platform == RuntimePlatform.Android)
+#if UNITY_EDITOR
+        Debug.Log("SendToFlutter - " + data);
+#elif UNITY_ANDROID
+        // Use reflection to call the relevant static Kotlin method in the Android plugin
+        using (AndroidJavaClass sendToFlutterClass = new AndroidJavaClass("com.learntoflutter.flutter_embed_unity_android.messaging.SendToFlutter"))
         {
-            // Use reflection to call the relevant static Kotlin method in the Android plugin
-            using (AndroidJavaClass sendToFlutterClass = new AndroidJavaClass("com.learntoflutter.flutter_embed_unity_android.messaging.SendToFlutter"))
-            {
-                sendToFlutterClass.CallStatic("sendToFlutter", data);
-            }
+            sendToFlutterClass.CallStatic("sendToFlutter", data);
         }
-        else
-        {
-#if UNITY_IOS
-            // Call an obj-C function name
-            FlutterEmbedUnityIos_sendToFlutter(data);
+#elif UNITY_IOS
+        // Call an obj-C function name
+        FlutterEmbedUnityIos_sendToFlutter(data);
 #endif
-        }
     }
 
 #if UNITY_IOS


### PR DESCRIPTION
This PR is mainly intended to fix #51, but also includes some additional cleanup.

The error in #51 is caused by platform specific iOS code that doesn't work in the Play mode of the Unity Editor.
This can easily be fixed by checking for NOT editor.
```diff
-#if UNITY_IOS
+#if UNITY_IOS && !UNITY_EDITOR
            // Call an obj-C function name
            FlutterEmbedUnityIos_sendToFlutter(data);
#endif
```

While updating this, I noticed Android uses a runtime check instead of compile-time.
So I combined both checks into `#if and #elif` logic.


In short:
- Fixes `#if UNITY_IOS` check by checking for `UNITY_EDITOR` first.
- Replace `Application.platform == RuntimePlatform.Android` with `#if UNITY_ANDROID` for efficiency.
- Debug.Log when `SendToFlutter.Send()` is called in the Unity Editor, to show the function does something.

The changes are identical for Unity 2022_3 and 6000_0