### PR TITLE
Update docs for Android 16KB page size requirements

### DIFF
--- a/flutter_embed_unity/README.md
+++ b/flutter_embed_unity/README.md
@@ -106,10 +106,16 @@ There is [an example Unity 2022.3 project](https://github.com/learntoflutter/flu
 
 At the time of writing, any version of Unity 6000.0 is working without reported issues
 
+* For Android, as of November 1st 2025, 6000.0.38 is required due to Google Play
+ requirements that all new apps and updates targeting Android 15+ [must support 16 KB page sizes](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html).
+  See [this announcement from Unity](https://discussions.unity.com/t/info-unity-engine-support-for-16-kb-memory-page-sizes-android-15/1589588) for more information.
 
 ### Unity 2022.3 LTS
 
 * For iOS, as of 1st May 2024, 2022.3.21 or later is required due to App Store requirements around apps and 3rd party SDKs (including Unity) [declaring required reason API usage using Privacy Manifests](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api). See [this announcement from Unity](https://forum.unity.com/threads/apple-privacy-manifest-updates-for-unity-engine.1529026/) for more information.
+* For Android, as of November 1st 2025, 2022.3.56 is required due to Google Play
+ requirements that all new apps and updates targeting Android 15+ (SDK 35) [must support 16 KB page sizes](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html).
+  See [this announcement from Unity](https://discussions.unity.com/t/info-unity-engine-support-for-16-kb-memory-page-sizes-android-15/1589588) for more information.
 * For Android 9 and later, any [Unity 2022.3 LTS](https://unity.com/releases/lts) is supported
 * For Android 8 and earlier, due to [issue #15](https://github.com/learntoflutter/flutter_embed_unity/issues/15), any version of Unity 2022.3 is supported **EXCEPT for 2022.3.10 to 2022.3.18** inclusive
 


### PR DESCRIPTION
## Description

> Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes.

[source](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html)

Unity [needs specific versions to be compatible](https://discussions.unity.com/t/info-unity-engine-support-for-16-kb-memory-page-sizes-android-15/1589588)


*   Unity 6000.1.0b5 released February 9, 2025
*    Unity 6000.0.38f1 released February 14, 2025
*   Unity 2022.3.56f1 released January 15, 2025

I've added 2022.3.56 and 6000.0.38 to the Readme, just like the privacy manifest requirement for iOS.

##
Looks like `Google ARCore XR Plugin` used in the `AR Foundation` package (in Unity) needs to be package 5.2+ or 6.2+ too.
Only 6.2 has it mentioned in the changelogs, but 5.2 was updated March 2025 and does not give me any errors on build or in the Google Play console.
